### PR TITLE
fix installation issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
+import codecs
+import os
+import re
 from setuptools import setup
 import sys
 
 cmdclass = {}
-
-from tarantool_queue import __version__
 
 try:
     from setuptools import setup
@@ -16,10 +17,26 @@ try:
 except ImportError:
     pass
 
+
+def read(*parts):
+    filename = os.path.join(os.path.dirname(__file__), *parts)
+    with codecs.open(filename, encoding='utf-8') as fp:
+        return fp.read()
+
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+
 setup(name='tarantool-queue',
-      version=__version__,
+      version=find_version('tarantool_queue', '__init__.py'),
       description='Python bindings for Tarantool queue script (http://github.com/tarantool/queue)',
-      long_description=open('README.rst').read(),
+      long_description=read('README.rst'),
       author='Eugine Blikh',
       author_email='bigbes@gmail.com',
       maintainer='Eugine Blikh',

--- a/tarantool_queue/__init__.py
+++ b/tarantool_queue/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 from tarantool_queue import Task, Tube, Queue
 __all__ = [Task, Tube, Queue, __version__]


### PR DESCRIPTION
Unable to install using `pip install tarantool-queue`.

Supplied patch with fix for `setup.py`. `setup.py` parse `__init__.py` to find a version.

```
$ pip install tarantool-queue
Downloading/unpacking tarantool-queue
  Downloading tarantool-queue-0.1.1.tar.gz
  Running setup.py (path:/Users/e.iskandarov/.virtualenvs/t1/build/tarantool-queue/setup.py) egg_info for package tarantool-queue
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/Users/e.iskandarov/.virtualenvs/t1/build/tarantool-queue/setup.py", line 6, in <module>
        from tarantool_queue import __version__
      File "tarantool_queue/__init__.py", line 3, in <module>
        from tarantool_queue import Task, Tube, Queue
      File "tarantool_queue/tarantool_queue.py", line 4, in <module>
        import msgpack
    ImportError: No module named msgpack
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/Users/e.iskandarov/.virtualenvs/t1/build/tarantool-queue/setup.py", line 6, in <module>

    from tarantool_queue import __version__

  File "tarantool_queue/__init__.py", line 3, in <module>

    from tarantool_queue import Task, Tube, Queue

  File "tarantool_queue/tarantool_queue.py", line 4, in <module>

    import msgpack

ImportError: No module named msgpack

----------------------------------------
Cleaning up...
```
